### PR TITLE
i18n

### DIFF
--- a/includes/summary-fields.php
+++ b/includes/summary-fields.php
@@ -26,16 +26,16 @@ function quick_summary_meta_box_fields( $post ) {
 		
 		?>	
 		<p>
-				<label for="quicksummary_title">Title</label><br />
+				<label for="quicksummary_title"><?php _e( 'Summary Title', 'quicksummary' ); ?></label><br />
 				<input type="text" class="all-options" name="quicksummary_title" id="quicksummary_title" value="<?php echo esc_attr( $title ); ?>" />
-				<span class="description">Title you wanna label, e.g Quick Summary</span>
+				<span class="description"><?php _e( 'Title you wanna label, e.g Quick Summary', 'quicksummary' ); ?></span>
 		</p>
 		
 		<p>
-				<label for="quicksummary_textarea">Textarea</label><br />
+				<label for="quicksummary_textarea"><?php _e( 'Summary Content', 'quicksummary' ); ?></label><br />
 				<textarea name="quicksummary_textarea" id="quicksummary_textarea" cols="60" rows="4" style="width:97%" ><?php echo esc_attr( $textarea ); ?></textarea> <br />
 				
-				<span class="description">The excerpt or summary of the post</span>
+				<span class="description"><?php _e( 'The excerpt or summary of the post', 'quicksummary' ); ?></span>
 		</p>
 
 		<?php 

--- a/quicksummary.php
+++ b/quicksummary.php
@@ -8,12 +8,12 @@ Author:            Horlaes
 Author URI:        https://github.com/horlaes/
 Donate link:       https://devsrealm.com
 Tags:              metabox, quote field
-Version:           1.0
-Stable tag:        1.0
-Requires at least: 3.5
-Tested up to:      4.9
+Version:           1.0.0
+Stable tag:        1.0.0
+Requires at least: 1.0.0
+Tested up to:      1.1.2
 Text Domain:       quicksummary
-Domain Path:       /languages
+Domain Path:       /languages/
 License:           GPL v2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
 
@@ -38,13 +38,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 }
 
-// if admin area
-if ( is_admin() ) {
+/* Set plugin version constant. */
+define( 'QUICK_SUMMARY_VERSION', '1.0.0' );
 
-    // include dependencies
-    require_once plugin_dir_path( __FILE__ ) . 'includes/summary-fields.php';
+define( 'QUICK_SUMMARY__FILE__', __FILE__ );
+define( 'QUICK_SUMMARY_PLUGIN_BASE', plugin_basename( QUICK_SUMMARY__FILE__ ) );
+define( 'QUICK_SUMMARY_URL', plugins_url( '/', QUICK_SUMMARY__FILE__ ) );
+define( 'QUICK_SUMMARY_PATH', plugin_dir_path( QUICK_SUMMARY__FILE__ ) );
+define( 'QUICK_SUMMARY_ADMIN_PATH', QUICK_SUMMARY_PATH . 'admin/' );
+define( 'QUICK_SUMMARY_INCLUDES_PATH', QUICK_SUMMARY_PATH . 'includes/' );
 
+/**
+ * Load plugins file
+ * @since 1.0.0
+ */
+function quick_summary_plugins_loaded(){
+
+	/* Load Text Domain (Language Translation) */
+	load_plugin_textdomain( 'quicksummary', false, QUICK_SUMMARY_PLUGIN_BASE . '/languages/' );
+	
+	// if admin area
+	if ( is_admin() ) {
+		// include dependencies
+		require_once QUICK_SUMMARY_INCLUDES_PATH . 'summary-fields.php';
+	}
 }
+add_action( 'plugins_loaded', 'quick_summary_plugins_loaded' );
 
 // enqueue public style
 function quicksummary_enqueue_style_public() {


### PR DESCRIPTION
Constants definition plus internationalization and localization of the plugin

This PR defines some plugin specific constants and plugin textdomain to aid in localization of public facing strings. The definitions would become useful for checking if the plugin is active by themes before returning the output markup.

It also includes some minor changes in text i.e from "Title" to "Summary Title" and "Textarea" to "Summary Content"

Example function for the FeatherLite theme can be seen in this [Gist](https://gist.github.com/zulfgani/10ff6fed5394eca351b55c6a0caae13d)
